### PR TITLE
Replace proxy-manager library with proxy-manager-lts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "brightnucleus/exceptions": ">=0.2",
     "brightnucleus/config": ">=0.4.7",
-    "ocramius/proxy-manager": "~2.0"
+    "friendsofphp/proxy-manager-lts": "~1.0.16"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR replaces the proxy-manager library with proxy-manager-lts to try to avoid conflicts with php 8.1